### PR TITLE
Add new scenarios and cases; unify id with title (Closes #2)

### DIFF
--- a/src/content/cases/ce-0582-chromium-empty-span-recreated-after-delete-ko.md
+++ b/src/content/cases/ce-0582-chromium-empty-span-recreated-after-delete-ko.md
@@ -1,5 +1,5 @@
 ---
-id: ce-0582-ko
+id: ce-0582-chromium-empty-span-recreated-after-delete-ko
 scenarioId: scenario-inline-element-recreation-after-delete
 locale: ko
 os: Windows

--- a/src/content/cases/ce-0582-chromium-empty-span-recreated-after-delete.md
+++ b/src/content/cases/ce-0582-chromium-empty-span-recreated-after-delete.md
@@ -1,5 +1,5 @@
 ---
-id: ce-0582
+id: ce-0582-chromium-empty-span-recreated-after-delete
 scenarioId: scenario-inline-element-recreation-after-delete
 locale: en
 os: Windows

--- a/src/content/cases/ce-0583-select-all-non-editable-block-first-last-child-ko.md
+++ b/src/content/cases/ce-0583-select-all-non-editable-block-first-last-child-ko.md
@@ -1,5 +1,5 @@
 ---
-id: ce-0583-ko
+id: ce-0583-select-all-non-editable-block-first-last-child-ko
 scenarioId: scenario-select-all-non-editable-block
 locale: ko
 os: macOS

--- a/src/content/cases/ce-0583-select-all-non-editable-block-first-last-child.md
+++ b/src/content/cases/ce-0583-select-all-non-editable-block-first-last-child.md
@@ -1,5 +1,5 @@
 ---
-id: ce-0583
+id: ce-0583-select-all-non-editable-block-first-last-child
 scenarioId: scenario-select-all-non-editable-block
 locale: en
 os: macOS

--- a/src/content/cases/ce-0584-ios-safari-inputtype-null-forced-render-breaks-sync-ko.md
+++ b/src/content/cases/ce-0584-ios-safari-inputtype-null-forced-render-breaks-sync-ko.md
@@ -1,0 +1,84 @@
+---
+id: ce-0584-ios-safari-inputtype-null-forced-render-breaks-sync-ko
+scenarioId: scenario-ios-safari-contenteditable-do-not-force-rerender-or-change-selection-during-input
+locale: ko
+os: iOS
+osVersion: "17"
+device: Phone
+deviceVersion: iPhone 15
+browser: Safari
+browserVersion: "17"
+keyboard: US QWERTY / 음성 받아쓰기
+caseTitle: iOS Safari — inputType이 undefined/null이거나 다중 insertText일 때 강제 재렌더 시 모델–DOM 동기화 깨짐
+description: "iOS Safari에서 input/beforeinput이 inputType undefined 또는 null로 오거나, insertText가 여러 번(음성 등) 올 수 있다. 이때 에디터가 강제 재렌더나 선택 변경을 하면 모델과 DOM이 어긋나 이후 입력이 깨져 보인다."
+tags: ["ios", "safari", "input", "inputType", "voice", "dictation", "re-render", "model-sync"]
+status: draft
+domSteps:
+  - label: "1단계: 사용자가 텍스트 입력 (키보드 또는 음성)"
+    html: '<div contenteditable="true">Hello </div>'
+    description: "첫 input 이벤트 발생; inputType이 'insertText' 또는 undefined/null일 수 있음."
+  - label: "2단계: 에디터가 강제 재렌더 또는 선택 변경"
+    html: '<div contenteditable="true">Hello </div>'
+    description: "에디터가 모델을 DOM에 쓰거나 선택을 복원; DOM/선택이 덮어쓰이거나 이동함."
+  - label: "3단계: 다음 입력이 잘못된 위치에 적용 (버그)"
+    html: '<div contenteditable="true">World Hello </div>'
+    description: "이어지는 insertText(또는 다음 덩어리)가 잘못된 오프셋에 적용되어 모델과 DOM이 일치하지 않음."
+  - label: "✅ 예상"
+    html: '<div contenteditable="true">Hello World </div>'
+    description: "에디터는 입력만 관찰하고 모델만 갱신; 스트림 중 재렌더/선택 변경 없음; 텍스트가 올바른 순서로 유지됨."
+---
+
+## 현상
+
+iOS Safari에서는 `input`·`beforeinput` 이벤트에 항상 유효한 `event.inputType`이 붙지 않는다. 음성 받아쓰기나 일부 시스템 텍스트 삽입 경로에서는 `inputType`이 `undefined` 또는 `null`인데도 브라우저는 DOM에 변경을 적용한다. 또한 음성 받아쓰기는 `insertText` 이벤트를 연속으로 여러 번 보낸다(단어 단위나 덩어리로). 이때 에디터가 이 중 어떤 이벤트에 대해 강제 재렌더(현재 모델을 DOM에 다시 쓰기, 또는 React에서 state 기준 재렌더)나 선택(selection)을 프로그램적으로 바꾸면:
+
+1. **inputType이 undefined/null일 때**: 에디터가 "inputType을 모를 때"를 "모델 기준 동기화" 또는 "선택 복원"으로 처리하면, 방금 브라우저가 적용한 내용을 덮어쓰거나 캐럿을 옮긴다. 그다음 input이 잘못된 위치에 적용되고, 그 시점부터 모델과 DOM이 영구적으로 어긋난다. 사용자에게는 글자 순서가 뒤바뀌거나 중복되거나 "전부 깨진" 것처럼 보인다.
+2. **insertText가 여러 번 올 때**: 첫 insertText 직후 에디터가 재렌더하거나 선택을 옮기면, 두 번째 이후 insertText가 (이미 잘못된) 선택 위치나 방금 모델로 교체된 DOM에 적용된다. 최종 텍스트가 틀리고 모델과 DOM을 다시 맞출 수 없게 된다.
+
+iOS 음성 받아쓰기에서는 composition 이벤트가 오지 않아, 에디터가 composition 구간으로 입력을 "묶어서" 처리할 수 없다. 안전한 방법은 입력 스트림 동안 강제 재렌더와 선택 변경을 하지 않고, 관찰만 하며 모델만 갱신하는 것이다.
+
+## 재현 단계
+
+1. iPhone 또는 iPad의 iOS Safari에서, 매 `input`마다 모델 state로 재렌더하는 contenteditable 기반 에디터(예: 제어 컴포넌트인 React) 또는 매 input 후 선택을 복원하는 에디터를 사용한다.
+2. 다음 중 하나를 수행한다.
+   - 키보드로 여러 글자를 빠르게 입력하거나,
+   - 음성 받아쓰기로 문구를 넣는다(예: "Hello world").
+3. 입력 스트림 중간에 에디터가 DOM을 강제 갱신하거나 선택을 바꾸는 경우(예: `event.inputType`이 undefined/null인 이벤트에서, 또는 받아쓰기 문구의 첫 insertText 직후) 다음을 확인한다.
+   - 이어지는 글자나 덩어리가 잘못된 위치에 나타난다.
+   - 화면 텍스트와 에디터 내부 모델이 갈라진다.
+   - 포커스를 잃거나 새로고침할 때까지 추가 타이핑/받아쓰기가 잘못된 위치에 적용되어 에디터가 "깨진" 것처럼 보인다.
+
+## 관찰된 동작
+
+- **이벤트 순서**: `inputType: 'insertText'`(또는 undefined/null)와 텍스트 일부를 담은 `data`로 `beforeinput`/`input` 발생 → 브라우저가 DOM 갱신. 이때 에디터가 "모델에서 동기화" 또는 "선택 복원"을 실행하면 DOM 또는 선택이 덮어쓰인다. 그다음 `beforeinput`/`input`에 더 많은 텍스트가 오면, 이전 또는 잘못된 오프셋에 적용된다. 결과: 텍스트 중복, 순서 뒤바뀜, 캐럿 잘못된 위치에서 이후 입력 전부 깨짐.
+- **inputType undefined/null**: iOS Safari에서 음성 받아쓰기 및 일부 입력 경로에서 확인됨. 스펙상 inputType은 비어 있을 수 있으며, MDN에서도 null/undefined 반환 가능을 기술함. "inputType 없음 → 강제 동기화"를 하면 첫 덮어쓰기와 영구적 동기화 깨짐이 발생함.
+- **다중 insertText**: 음성 받아쓰기는 여러 번의 insertText(예: 단어별·구간별)를 보낸다. 첫 번째 직후 재렌더나 선택 변경 시 나머지가 잘못 적용됨.
+
+## 예상 동작
+
+에디터는 input 핸들러에서 DOM(또는 이벤트)만 읽어 모델을 갱신해야 한다. 같은 입력 "폭발" 동안에는 모델을 DOM에 다시 쓰지 않고 Selection도 바꾸지 않아야 한다. inputType이 undefined 또는 null이어도 "알 수 없으니 모델로 DOM 덮어쓰기"로 해석하지 않는다. 입력이 안정된 뒤(debounce, blur 등)에만 필요 시 모델 기준으로 DOM을 맞출 수 있다.
+
+## 영향
+
+- **모델–DOM 영구적 어긋남**: 잘못된 순간에 강제 재렌더나 선택 변경이 한 번이라도 일어나면, 세션 동안 모델과 DOM을 안정적으로 맞출 수 없고 글자가 깨지거나 순서가 틀려 보인다.
+- **음성 입력 불안정**: 음성 받아쓰기가 다중 insertText와 가끔 undefined inputType의 대표 사례이므로, 매 input마다 재렌더하거나 선택을 건드리는 에디터는 iOS Safari에서 음성 입력을 불안정하게 만든다.
+- **제어 컴포넌트**: 매 input마다 state로 DOM을 맞추는 React 등은 iOS에서 재렌더가 입력 스트림 중에 발생하지 않도록(관찰 전용 + debounce/blur 동기화) 하지 않으면 위험도가 높다.
+
+## 브라우저 비교
+
+- **iOS Safari**: inputType이 undefined/null일 수 있음; 음성 시 insertText 다중; 입력 중 강제 재렌더·선택 변경 시 동기화 깨짐 및 이후 입력 깨짐.
+- **macOS Safari / Chrome / Firefox**: inputType은 보통 설정됨; 매 input 재렌더는 캐럿 점프 등은 유발할 수 있으나 iOS Safari만큼 영구적 동기화 깨짐을 일으키지는 않을 수 있음.
+
+## 해결 방법
+
+1. **관찰 전용**: `input`/`beforeinput`에서는 DOM 또는 이벤트에서만 모델을 갱신하고, 같은 틱 또는 빠른 연속 이벤트 동안에는 모델을 DOM에 쓰지 않으며 선택도 바꾸지 않는다.
+2. **inputType이 falsy일 때 강제 동기화 금지**: `event.inputType`이 undefined 또는 null이면 "모델→DOM 동기화" 또는 "선택 복원"을 실행하지 않고, 읽기만 하고 모델만 갱신한다.
+3. **모델→DOM은 지연**: DOM에 모델을 반영해야 하면 입력이 안정된 뒤(debounce, blur, 명시적 flush)에 수행하고, input 핸들러 안에서는 하지 않는다.
+4. **비제어 또는 하이브리드**: 편집 중에는 contenteditable을 진실의 원천으로 두고, blur나 debounce 시점에만 프레임워크 state와 동기화해 재렌더가 입력 스트림 중에 발생하지 않게 한다.
+
+## 참고 자료
+
+- [WebKit Bug 261764: iOS/iPadOS dictation doesn't trigger composition events](https://bugs.webkit.org/show_bug.cgi?id=261764)
+- [MDN: InputEvent.inputType](https://developer.mozilla.org/en-US/docs/Web/API/InputEvent/inputType)
+- [Stack Overflow: Safari에서 재렌더 시 캐럿 위치 복원](https://stackoverflow.com/questions/40537746/caret-position-reverts-to-start-of-contenteditable-span-on-re-render-in-react-in)
+- [시나리오: iOS Safari contenteditable 입력 중 강제 재렌더·선택 변경 금지](scenario-ios-safari-contenteditable-do-not-force-rerender-or-change-selection-during-input)

--- a/src/content/cases/ce-0584-ios-safari-inputtype-null-forced-render-breaks-sync.md
+++ b/src/content/cases/ce-0584-ios-safari-inputtype-null-forced-render-breaks-sync.md
@@ -1,0 +1,84 @@
+---
+id: ce-0584-ios-safari-inputtype-null-forced-render-breaks-sync
+scenarioId: scenario-ios-safari-contenteditable-do-not-force-rerender-or-change-selection-during-input
+locale: en
+os: iOS
+osVersion: "17"
+device: Phone
+deviceVersion: iPhone 15
+browser: Safari
+browserVersion: "17"
+keyboard: US QWERTY / Voice dictation
+caseTitle: iOS Safari — forced re-render when inputType is undefined/null or during multi insertText breaks model–DOM sync
+description: "On iOS Safari, input/beforeinput can fire with inputType undefined or null, or with insertText multiple times (voice). If the editor forces re-render or changes selection in response, the model and DOM desync and subsequent input appears broken."
+tags: ["ios", "safari", "input", "inputType", "voice", "dictation", "re-render", "model-sync"]
+status: draft
+domSteps:
+  - label: "Step 1: User enters text (keyboard or voice)"
+    html: '<div contenteditable="true">Hello </div>'
+    description: "First input event(s) fire; inputType may be 'insertText' or undefined/null."
+  - label: "Step 2: Editor forces re-render or selection change"
+    html: '<div contenteditable="true">Hello </div>'
+    description: "Editor writes model to DOM or restores selection; DOM/selection overwritten or moved."
+  - label: "Step 3: Next input applies at wrong place (bug)"
+    html: '<div contenteditable="true">World Hello </div>'
+    description: "Subsequent insertText (or next chunk) applies at wrong offset; model and DOM no longer match."
+  - label: "✅ Expected"
+    html: '<div contenteditable="true">Hello World </div>'
+    description: "Editor only observes input and updates model; no re-render/selection change during stream; all text in correct order."
+---
+
+## Phenomenon
+
+On iOS Safari, `input` and `beforeinput` events are not always accompanied by a valid `event.inputType`. In some code paths (including voice dictation and certain system text insertions), `inputType` is `undefined` or `null` while the browser still applies a change to the DOM. In addition, voice dictation sends multiple `insertText` events in sequence (e.g. word by word or in chunks). If the editor responds to any of these events by forcing a re-render (e.g. writing the current model back to the DOM, or React re-rendering from state) or by programmatically changing the selection, two things happen:
+
+1. When inputType is undefined/null: The editor may treat "unknown input type" as a signal to "sync from model" or "restore selection". That overwrites or repositions what the browser just did. The next input event then applies to the wrong place, and from that point on the model and DOM are permanently out of sync. The user sees characters in the wrong order, duplicated, or "all broken".
+2. When insertText fires multiple times: After the first insertText, the editor re-renders or moves the selection. The second and later insertText events apply to the (now wrong) selection or to a DOM that was just replaced by the model. The final text is wrong and the model can no longer be reconciled with the DOM.
+
+No composition events fire during iOS dictation, so the editor cannot rely on composition boundaries to "batch" input. The only safe approach is to not force re-render and not change selection during the input stream; only observe and update the model.
+
+## Reproduction Steps
+
+1. Use iOS Safari on an iPhone or iPad with a contenteditable-based editor that re-renders from model state on each `input` (e.g. controlled React component), or that restores selection after each input.
+2. Either:
+   - Type several characters quickly, or
+   - Use voice dictation to insert a phrase (e.g. "Hello world").
+3. If the editor force-updates the DOM or selection in the middle of the input stream (e.g. on an event where `event.inputType` is undefined/null, or after the first insertText of a dictation phrase), observe that:
+   - Subsequent characters or chunks appear in the wrong place.
+   - The displayed text and the editor’s internal model diverge.
+   - Further typing or dictation continues to go to the wrong position; the editor appears "broken" until focus is lost or the page is reloaded.
+
+## Observed Behavior
+
+- **Event sequence**: `beforeinput` / `input` with `inputType: 'insertText'` (or undefined/null) and `data` containing part of the text. Browser updates DOM. If the editor then runs "sync from model" or "restore selection", the DOM or selection is overwritten. Next `beforeinput` / `input` fires with more text; it applies at the old or wrong offset. Result: duplicated text, reversed order, or caret in wrong place and all following input broken.
+- **inputType undefined/null**: Observed on iOS Safari when using voice dictation and in some other input paths. The spec allows inputType to be empty; MDN notes it may return null or undefined. Using "no inputType → force sync" causes the first overwrite and permanent desync.
+- **Multiple insertText**: Voice dictation often sends several insertText events (e.g. one per word or per segment). Re-rendering or selection change after the first one makes the rest apply incorrectly.
+
+## Expected Behavior
+
+The editor should only read from the DOM (or from the event) in the input handler and update its model. It should not write the model back to the DOM and should not change the Selection during the same input "burst". When inputType is undefined or null, the editor must not interpret that as "unknown, so overwrite DOM from model". After input has settled (e.g. debounce or blur), the editor may optionally reconcile DOM from model if needed.
+
+## Impact
+
+- **Permanent model–DOM desync**: Once a forced re-render or selection change happens in the wrong moment, the editor cannot reliably sync model and DOM for the rest of the session; characters appear broken or in wrong order.
+- **Voice input unreliable**: Voice dictation is the main case where multiple insertText and sometimes undefined inputType occur; editors that re-render or tweak selection on every input make dictation unusable on iOS Safari.
+- **Controlled components**: React and similar frameworks that sync DOM from state on every input are high risk on iOS unless they avoid re-rendering the contenteditable during the input stream (e.g. observer-only + debounced or blur sync).
+
+## Browser Comparison
+
+- **iOS Safari**: inputType can be undefined/null; multiple insertText for voice; forced re-render or selection change during input leads to desync and broken subsequent input.
+- **macOS Safari / Chrome / Firefox**: inputType is usually set; re-render on every input may cause caret jump but often does not cause the same permanent desync as on iOS Safari.
+
+## Solutions
+
+1. **Observer-only**: In `input`/`beforeinput`, only update the model from the DOM or event; do not write model to DOM and do not change selection in the same tick or during a rapid sequence of events.
+2. **Never force sync when inputType is falsy**: If `event.inputType` is undefined or null, do not run "sync from model to DOM" or "restore selection"; only read and update model.
+3. **Debounce or blur for model→DOM**: If the editor must reflect model in DOM, do it after input has settled (debounce, blur, or explicit flush), not inside the input handler.
+4. **Uncontrolled or hybrid**: Keep contenteditable as source of truth during editing; sync to framework state only on blur or debounced tick so that re-renders do not run during the critical input stream.
+
+## References
+
+- [WebKit Bug 261764: iOS/iPadOS dictation doesn't trigger composition events](https://bugs.webkit.org/show_bug.cgi?id=261764)
+- [MDN: InputEvent.inputType](https://developer.mozilla.org/en-US/docs/Web/API/InputEvent/inputType)
+- [Stack Overflow: Caret position reverts on re-render in Safari](https://stackoverflow.com/questions/40537746/caret-position-reverts-to-start-of-contenteditable-span-on-re-render-in-react-in)
+- [Scenario: iOS Safari contenteditable do not force re-render or change selection during input](scenario-ios-safari-contenteditable-do-not-force-rerender-or-change-selection-during-input)

--- a/src/content/scenarios/scenario-inline-element-recreation-after-delete-ko.md
+++ b/src/content/scenarios/scenario-inline-element-recreation-after-delete-ko.md
@@ -73,7 +73,7 @@ editor.addEventListener('input', () => {
 
 ## 관련 케이스
 
-- [ce-0582](ce-0582-chromium-empty-span-recreated-after-delete) – Chromium에서 빈 span 삭제 후 입력 시 다시 생성됨
+- [ce-0582-chromium-empty-span-recreated-after-delete](ce-0582-chromium-empty-span-recreated-after-delete) – Chromium에서 빈 span 삭제 후 입력 시 다시 생성됨
 
 ## 참고 자료
 

--- a/src/content/scenarios/scenario-inline-element-recreation-after-delete.md
+++ b/src/content/scenarios/scenario-inline-element-recreation-after-delete.md
@@ -73,7 +73,7 @@ editor.addEventListener('input', () => {
 
 ## Related Cases
 
-- [ce-0582](ce-0582-chromium-empty-span-recreated-after-delete) – Chromium empty span recreated after delete and type
+- [ce-0582-chromium-empty-span-recreated-after-delete](ce-0582-chromium-empty-span-recreated-after-delete) – Chromium empty span recreated after delete and type
 
 ## References
 

--- a/src/content/scenarios/scenario-ios-dictation-duplicate-events-ko.md
+++ b/src/content/scenarios/scenario-ios-dictation-duplicate-events-ko.md
@@ -477,6 +477,7 @@ React Native 애플리케이션에서도 iOS dictation과 관련된 유사한 �
 
 ## 참고 자료
 
+- [시나리오: iOS Safari contenteditable 입력 중 강제 재렌더·선택 변경 금지](scenario-ios-safari-contenteditable-do-not-force-rerender-or-change-selection-during-input) - 입력 중 재렌더·선택 변경 금지; inputType이 undefined/null일 수 있음; 모델–DOM 동기화 깨짐 방지
 - [WebKit Bug 261764: iOS/iPadOS dictation doesn't trigger composition events](https://bugs.webkit.org/show_bug.cgi?id=261764) - Composition events not firing
 - [W3C UI Events: Composition events](https://www.w3.org/TR/2016/WD-uievents-20160804/) - Composition event specification
 - [Reddit: Dictation input jumping around](https://www.reddit.com//r/ios/comments/1pfv6c4/dictation_input_jumping_around/) - User reports of duplicate text

--- a/src/content/scenarios/scenario-ios-dictation-duplicate-events.md
+++ b/src/content/scenarios/scenario-ios-dictation-duplicate-events.md
@@ -477,6 +477,7 @@ This suggests similar issues may occur in web applications.
 
 ## References
 
+- [Scenario: iOS Safari contenteditable do not force re-render or change selection during input](scenario-ios-safari-contenteditable-do-not-force-rerender-or-change-selection-during-input) - Do not re-render or change selection during input; inputType may be undefined/null; prevents model–DOM desync
 - [WebKit Bug 261764: iOS/iPadOS dictation doesn't trigger composition events](https://bugs.webkit.org/show_bug.cgi?id=261764) - Composition events not firing
 - [W3C UI Events: Composition events](https://www.w3.org/TR/2016/WD-uievents-20160804/) - Composition event specification
 - [Reddit: Dictation input jumping around](https://www.reddit.com//r/ios/comments/1pfv6c4/dictation_input_jumping_around/) - User reports of duplicate text

--- a/src/content/scenarios/scenario-ios-safari-input-observer-only-no-forced-render-ko.md
+++ b/src/content/scenarios/scenario-ios-safari-input-observer-only-no-forced-render-ko.md
@@ -1,0 +1,84 @@
+---
+id: scenario-ios-safari-contenteditable-do-not-force-rerender-or-change-selection-during-input-ko
+title: iOS Safari contenteditable — 입력 중 강제 재렌더·선택 변경 금지
+description: "iOS Safari에서는 input/beforeinput이 inputType 'insertText'로 여러 번 오거나(음성 입력 등), inputType이 undefined/null로 올 수 있다. 이 흐름 중에 강제 재렌더나 선택 변경을 하면 에디터 모델과 DOM이 어긋나고, 이후 입력이 영구적으로 깨질 수 있다."
+category: ime
+tags:
+  - ios
+  - safari
+  - input
+  - beforeinput
+  - inputType
+  - voice
+  - dictation
+  - re-render
+  - model-sync
+  - selection
+status: draft
+locale: ko
+---
+
+## 문제 개요
+
+iOS Safari에서 사용자가 contenteditable에서 입력하거나 음성으로 입력할 때, 에디터는 입력을 **관찰**하고 내부 모델만 갱신해야 한다. 입력 스트림이 진행되는 **도중에** 강제 재렌더(예: 모델에서 DOM으로 다시 쓰기)나 선택(selection)을 프로그램적으로 바꾸면 안 된다. 이유는 두 가지다.
+
+1. **insertText가 여러 번 옴**: 음성 입력은 `inputType: 'insertText'`인 `beforeinput`/`input`을 여러 번 보낸다(단어 단위나 덩어리로). 첫 번째 이벤트 직후에 에디터가 재렌더하거나 선택을 옮기면, 그 다음 이벤트들이 잘못된 위치에 적용되어 모델과 DOM이 어긋난다.
+2. **inputType이 undefined나 null일 수 있음**: iOS에서는 `event.inputType`이 보장되지 않는다. undefined나 null이어도 브라우저는 변경을 적용한다. 이때 "inputType을 모르니까"라고 하고 강제 동기화나 모델 기준 재렌더를 하면, DOM을 덮어쓰거나 어긋나게 한다. 그 순간부터 이후 입력이 "깨진" 것처럼 보이고, 모델과 DOM을 다시 맞출 수 없게 된다.
+
+안전한 패턴은 **입력을 관찰하고, DOM(또는 이벤트)에서만 모델을 갱신하며, 입력 흐름이 끝나기 전에는 DOM이나 선택을 다시 쓰지 않는 것**이다.
+
+## 관찰된 동작
+
+- **insertText 다중 발생**: 음성 입력 시 insertText 이벤트가 연속으로 온다. 첫 이벤트 후 DOM에는 이미 일부만 반영되고, 다음 이벤트에 나머지 텍스트가 온다. 그 사이에 에디터가 재렌더(예: React setState → DOM 교체)하거나 선택을 복원하면, 두 번째 이후 이벤트가 잘못된 위치에 적용되어 최종 텍스트가 틀리거나 중복된다.
+- **inputType undefined/null**: iOS Safari의 일부 경로에서는 `input` 또는 `beforeinput`이 `event.inputType === undefined` 또는 `null`인 채로 발생한다. DOM은 그대로 브라우저에 의해 갱신된다. "inputType이 없으면 모델→DOM 강제 동기화" 또는 "inputType이 없으면 선택 복원" 같은 처리를 하면, 브라우저가 적용한 변경을 덮어쓰거나 캐럿을 옮겨 버린다. 그 시점부터 모델과 DOM이 갈라지고, 이후 타이핑/음성 입력이 깨져 보인다.
+- **선택 변경**: 입력 스트림 도중에 `selection.removeAllRanges()` / `addRange()` 등으로 선택을 바꾸면, 재렌더와 같은 효과로 다음 이벤트가 잘못된 위치에 적용되어 동기화가 깨진다.
+
+## 영향
+
+- **영구적 동기화 깨짐**: inputType이 null/undefined인 이벤트에서, 또는 다중 insertText 스트림 도중에 강제 재렌더나 선택 변경을 한 번이라도 하면, 모델과 DOM이 더 이상 맞지 않는다. 이후 입력은 잘못된 위치에 쌓이거나 덮어쓰며, 사용자에게는 "글자가 모두 깨진다" 또는 순서가 뒤섞인 것처럼 보인다.
+- **음성 입력 사용 불가에 가까움**: 음성 입력이 다중 insertText의 대표적 케이스이므로, dictation 중 재렌더나 선택 조작은 iOS에서 음성 입력을 불안정하게 만든다.
+- **제어 컴포넌트**: 매 입력마다 state를 갱신해 DOM을 state로 맞추는 React 등 "제어" 패턴은, 매 키 입력/input마다 재렌더에 해당하므로 위 조건에서 특히 위험하다.
+
+## 브라우저 비교
+
+- **iOS Safari**: inputType이 undefined/null일 수 있음; 음성 입력 시 insertText가 여러 번 옴; 입력 중 재렌더나 선택 변경 시 동기화 깨짐 및 이후 입력 깨짐.
+- **macOS Safari / Chrome / Firefox**: inputType은 대체로 설정됨; dictation은 composition 등 다른 이벤트 패턴일 수 있음; 매 input마다 재렌더는 캐럿 점프 등 위험은 있으나 iOS만큼 모델/DOM 영구적 어긋남을 유발하지는 않을 수 있음.
+
+## 해결 방법
+
+1. **입력 중에는 관찰만**: `input`/`beforeinput` 핸들러에서는 DOM(또는 이벤트)만 읽어서 에디터 모델을 갱신한다. 같은 틱(또는 입력 "폭발"이 끝나기 전)에는 모델을 DOM에 다시 쓰지 않고, Selection도 바꾸지 않는다.
+2. **inputType이 없을 때 강제 동기화 금지**: `event.inputType`이 `undefined` 또는 `null`이면 "알 수 없으니 모델로 DOM 덮어쓰기"를 하지 않는다. "브라우저가 변경을 적용했으니 읽기만 하고 모델만 갱신"으로 처리한다. inputType이 falsy일 때 force-sync나 재렌더를 수행하는 경로를 제거한다.
+3. **모델→DOM 쓰기는 지연**: 모델 상태를 DOM에 반영해야 한다면, 입력이 안정된 뒤(blur, debounce 등)에 수행하고, input 핸들러 안에서 동기적으로 하지 않는다. iOS에서는 빠른 연속 input(예: dictation) 중간에 재렌더를 하지 않는다.
+4. **비제어 또는 하이브리드**: 편집 중에는 contenteditable DOM을 진실의 원천으로 두고, blur나 debounce된 시점에만 프레임워크 state와 동기화하면, 재렌더가 입력 스트림 중에 발생하지 않는다.
+
+예: inputType이 없을 때 강제 재렌더를 하지 않기
+
+```javascript
+editable.addEventListener('input', (e) => {
+  // 읽기만 하고 모델만 갱신; 여기서 DOM에 다시 쓰지 않음
+  const newContent = editable.innerHTML; // 또는 e / getTargetRanges에서
+  updateModel(newContent);
+
+  // inputType이 undefined/null이거나 insertText 스트림 중에는 다음을 하지 말 것:
+  // setState(newContent);  // → React 재렌더 → DOM 교체 → iOS에서 동기화 깨짐
+  // selection.removeAllRanges(); selection.addRange(myRange);  // → 다음 입력이 잘못된 위치에
+});
+```
+
+## 모범 사례
+
+- iOS Safari에서는 inputType이 undefined/null일 수 있다고 가정하고, "inputType이 없으니 모델 기준으로 DOM/선택을 갱신한다"는 로직을 두지 않는다.
+- insertText가 연속으로 올 수 있다고 가정(음성 등); 그 사이에 재렌더나 선택 변경을 하지 않는다.
+- 관찰 전용 패턴을 우선한다: input 핸들러는 DOM/이벤트에서만 모델을 갱신하고, DOM/선택은 입력이 안정된 뒤(blur, debounce 등)에만 다시 쓴다.
+
+## 관련 케이스
+
+- [ce-0584-ios-safari-inputtype-null-forced-render-breaks-sync](ce-0584-ios-safari-inputtype-null-forced-render-breaks-sync) – iOS Safari: inputType undefined/null 또는 다중 insertText 시 강제 재렌더로 모델–DOM 동기화 깨짐
+- [ce-0293](ce-0293-ios-dictation-duplicate-events-safari) – iOS 음성 입력 중복 이벤트 (관련 이벤트 순서)
+
+## 참고 자료
+
+- [WebKit Bug 261764: iOS/iPadOS dictation doesn't trigger composition events](https://bugs.webkit.org/show_bug.cgi?id=261764)
+- [MDN: InputEvent.inputType](https://developer.mozilla.org/en-US/docs/Web/API/InputEvent/inputType) – "null or undefined를 반환할 수 있음"
+- [Stack Overflow: Safari에서 contenteditable 재렌더 시 캐럿이 맨 앞으로](https://stackoverflow.com/questions/40537746/caret-position-reverts-to-start-of-contenteditable-span-on-re-render-in-react-in)
+- [시나리오: iOS dictation duplicate events](scenario-ios-dictation-duplicate-events) – 음성 입력 시 이벤트 재발생; dictation 중 재렌더 시 악화

--- a/src/content/scenarios/scenario-ios-safari-input-observer-only-no-forced-render.md
+++ b/src/content/scenarios/scenario-ios-safari-input-observer-only-no-forced-render.md
@@ -1,0 +1,84 @@
+---
+id: scenario-ios-safari-contenteditable-do-not-force-rerender-or-change-selection-during-input
+title: iOS Safari contenteditable — do not force re-render or change selection during input
+description: "On iOS Safari, input and beforeinput can fire with inputType 'insertText' multiple times (e.g. voice dictation) or with inputType undefined/null. Forcing re-render or changing selection during this flow desyncs the editor model from the DOM and can permanently break subsequent input."
+category: ime
+tags:
+  - ios
+  - safari
+  - input
+  - beforeinput
+  - inputType
+  - voice
+  - dictation
+  - re-render
+  - model-sync
+  - selection
+status: draft
+locale: en
+---
+
+## Problem Overview
+
+On iOS Safari, when the user types or uses voice dictation in a `contenteditable` element, the editor must **observe** input and update its internal model only. It must **not** force a re-render (e.g. writing back DOM from the model) or programmatically change the selection in the middle of the input stream. Reasons:
+
+1. **Multiple insertText events**: Voice dictation sends `beforeinput` / `input` with `inputType: 'insertText'` multiple times (e.g. word by word or in chunks). If the editor re-renders or moves the selection after the first event, the following events apply to the wrong place and the model and DOM go out of sync.
+2. **inputType can be undefined or null**: On iOS, `event.inputType` is not guaranteed. When it is `undefined` or `null`, the browser is still applying a change. If the editor treats "unknown inputType" as a signal to force-sync or re-render from the model, it overwrites or misaligns the DOM. After that, all subsequent input appears "broken": the model can no longer be kept in sync with the DOM.
+
+The safe pattern is: **observe input, update the model from the DOM (or from the event), and do not write DOM or selection back during the input flow.**
+
+## Observed Behavior
+
+- **insertText multiple times**: Voice input produces a sequence of `insertText` events. After the first one, the DOM already contains part of the dictated text; the next event carries more text. If the editor re-renders (e.g. React setState → DOM replace) or restores selection after the first event, the second and later events apply to stale or wrong positions and the final text is wrong or duplicated.
+- **inputType undefined/null**: In some iOS Safari paths, `input` or `beforeinput` fires with `event.inputType === undefined` or `null`. The DOM is still updated by the browser. If the editor does something like "if (!inputType) force sync from model to DOM" or "if (!inputType) restore selection", it overwrites the browser’s change or moves the caret. From that point on, the model and DOM diverge and further typing/dictation appears broken.
+- **Selection change**: Programmatically calling `selection.removeAllRanges()` / `addRange()` or otherwise changing the selection during the input stream (e.g. after each `input`) has the same effect as re-rendering: the next event applies at the wrong place and sync is lost.
+
+## Impact
+
+- **Permanent desync**: Once the editor forces re-render or selection change on an event where inputType is null/undefined or in the middle of a multi-event insertText stream, the model and DOM no longer match. Later input accumulates in the wrong place or overwrites content; the user sees "all characters broken" or text in wrong order.
+- **Voice dictation unusable**: Voice input is the main trigger for multiple insertText events; re-rendering or selection tweaks during dictation make voice input unreliable on iOS.
+- **Controlled components**: React and other "controlled" patterns that sync DOM from state on every input are especially dangerous: they effectively force re-render on every keystroke or every input event, which breaks on iOS Safari under the above conditions.
+
+## Browser Comparison
+
+- **iOS Safari**: inputType can be undefined/null; voice dictation fires multiple insertText events; re-render or selection change during input leads to desync and broken subsequent input.
+- **macOS Safari / Chrome / Firefox**: inputType is usually set; dictation may fire composition or different event patterns; re-rendering on every input still risks caret jump but may not cause the same degree of permanent model/DOM desync as on iOS.
+
+## Solutions
+
+1. **Observer-only during input**: In `input` / `beforeinput` handlers, only read from the DOM (or from the event) and update the editor model. Do not write the model back to the DOM and do not change the Selection during the same tick (or until the input "burst" is over).
+2. **Never force sync when inputType is missing**: If `event.inputType` is `undefined` or `null`, do not treat it as "unknown, so overwrite DOM from model". Treat it as "browser applied a change; only read and update model". Avoid any path that does force-sync or re-render when inputType is falsy.
+3. **Debounce or batch model→DOM writes**: If the editor must eventually reflect model state in the DOM, do it after input has settled (e.g. debounce, or on blur), not synchronously inside the input handler. On iOS, avoid re-rendering in the middle of a rapid sequence of input events (e.g. dictation).
+4. **Uncontrolled or hybrid**: Consider keeping the contenteditable DOM as the source of truth during editing and only syncing to the framework state on blur or on a debounced tick, so that re-renders do not run during the critical input stream.
+
+Example: avoid forced re-render when inputType is missing:
+
+```javascript
+editable.addEventListener('input', (e) => {
+  // Only read and update model; do not write back to DOM here
+  const newContent = editable.innerHTML; // or get from e / getTargetRanges
+  updateModel(newContent);
+
+  // Do NOT do this when inputType is undefined/null (or during insertText stream):
+  // setState(newContent);  // → React re-renders → DOM replaced → desync on iOS
+  // selection.removeAllRanges(); selection.addRange(myRange);  // → next input at wrong place
+});
+```
+
+## Best Practices
+
+- On iOS Safari, assume `inputType` can be undefined or null; never use "missing inputType" as a reason to force DOM or selection update from the model.
+- Assume multiple `insertText` events in a row (e.g. voice); do not re-render or change selection between them.
+- Prefer observer-only pattern: input handler updates model from DOM/event only; DOM/selection are not written back until after input has settled (blur, debounce, or explicit "flush").
+
+## Related Cases
+
+- [ce-0584-ios-safari-inputtype-null-forced-render-breaks-sync](ce-0584-ios-safari-inputtype-null-forced-render-breaks-sync) – iOS Safari: inputType undefined/null or multiple insertText; forced re-render breaks model–DOM sync
+- [ce-0293](ce-0293-ios-dictation-duplicate-events-safari) – iOS dictation duplicate events (related event sequence)
+
+## References
+
+- [WebKit Bug 261764: iOS/iPadOS dictation doesn't trigger composition events](https://bugs.webkit.org/show_bug.cgi?id=261764)
+- [MDN: InputEvent.inputType](https://developer.mozilla.org/en-US/docs/Web/API/InputEvent/inputType) – "If inputType returns null or undefined..."
+- [Stack Overflow: Caret position reverts on re-render in React in Safari](https://stackoverflow.com/questions/40537746/caret-position-reverts-to-start-of-contenteditable-span-on-re-render-in-react-in)
+- [Scenario: iOS dictation duplicate events](scenario-ios-dictation-duplicate-events) – dictation event re-firing; re-render during dictation worsens the issue

--- a/src/content/scenarios/scenario-select-all-non-editable-block-ko.md
+++ b/src/content/scenarios/scenario-select-all-non-editable-block-ko.md
@@ -77,7 +77,7 @@ editor.addEventListener('keydown', (e) => {
 
 ## 관련 케이스
 
-- [ce-0583](ce-0583-select-all-non-editable-block-first-last-child) – 비편집 블록이 첫/끝 자식일 때 전체 선택 실패 (Safari/Chrome)
+- [ce-0583-select-all-non-editable-block-first-last-child](ce-0583-select-all-non-editable-block-first-last-child) – 비편집 블록이 첫/끝 자식일 때 전체 선택 실패 (Safari/Chrome)
 
 ## 참고 자료
 

--- a/src/content/scenarios/scenario-select-all-non-editable-block.md
+++ b/src/content/scenarios/scenario-select-all-non-editable-block.md
@@ -77,7 +77,7 @@ editor.addEventListener('keydown', (e) => {
 
 ## Related Cases
 
-- [ce-0583](ce-0583-select-all-non-editable-block-first-last-child) – Select All fails when non-editable block is first or last child (Safari/Chrome)
+- [ce-0583-select-all-non-editable-block-first-last-child](ce-0583-select-all-non-editable-block-first-last-child) – Select All fails when non-editable block is first or last child (Safari/Chrome)
 
 ## References
 


### PR DESCRIPTION
## Summary
- **New scenario (en+ko)**: iOS Safari contenteditable — do not force re-render or change selection during input (inputType undefined/null, multiple insertText).
- **New case (en+ko)**: ce-0584-ios-safari-inputtype-null-forced-render-breaks-sync.
- **Id convention**: Scenario and case ids now include title/description (e.g. `ce-0582-chromium-empty-span-recreated-after-delete`, `scenario-ios-safari-contenteditable-do-not-force-rerender-or-change-selection-during-input`). Updated ce-0582, ce-0583, ce-0584 and related scenario references.
- **Cross-links**: scenario-ios-dictation-duplicate-events references new iOS input observer scenario; inline recreation and select-all scenarios reference cases with long ids.

Closes #2

Made with [Cursor](https://cursor.com)